### PR TITLE
Use PSR-1 for PHPUnit TestCase

### DIFF
--- a/tests/FunctionsTest.php
+++ b/tests/FunctionsTest.php
@@ -1,10 +1,13 @@
 <?php
 
 /* vim: set expandtab sw=4 ts=4 sts=4: */
+
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for functions.
  */
-class FunctionsTest extends PHPUnit_Framework_TestCase
+class FunctionsTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -1,10 +1,13 @@
 <?php
 
 /* vim: set expandtab sw=4 ts=4 sts=4: */
+
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for mo loading.
  */
-class LoaderTest extends PHPUnit_Framework_TestCase
+class LoaderTest extends TestCase
 {
     /**
      * @dataProvider localeList

--- a/tests/MoFilesTest.php
+++ b/tests/MoFilesTest.php
@@ -1,10 +1,13 @@
 <?php
 
 /* vim: set expandtab sw=4 ts=4 sts=4: */
+
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for MO files parsing.
  */
-class MoFilesTest extends PHPUnit_Framework_TestCase
+class MoFilesTest extends TestCase
 {
     /**
      * @dataProvider provideMoFiles

--- a/tests/PluralFormulaTest.php
+++ b/tests/PluralFormulaTest.php
@@ -1,10 +1,13 @@
 <?php
 
 /* vim: set expandtab sw=4 ts=4 sts=4: */
+
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for gettext parsing.
  */
-class PluralFormlulaTest extends PHPUnit_Framework_TestCase
+class PluralFormlulaTest extends TestCase
 {
     /**
      * Test for extractPluralsForms.

--- a/tests/PluralTest.php
+++ b/tests/PluralTest.php
@@ -1,10 +1,13 @@
 <?php
 
 /* vim: set expandtab sw=4 ts=4 sts=4: */
+
+use PHPUnit\Framework\TestCase;
+
 /**
  * Test for gettext parsing.
  */
-class PluralTest extends PHPUnit_Framework_TestCase
+class PluralTest extends TestCase
 {
     /**
      * Test for npgettext.


### PR DESCRIPTION
Use [PSR-1](http://www.php-fig.org/psr/psr-1/#namespace-and-class-names) while extending PHPUnit TestCase class. This will help us when to migrate to PHPUnit 6, that [no longer support snake case namespaces](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).