### PR TITLE
Bump minimum version to PHP 7.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ composer.phar
 composer.lock
 .php_cs.cache
 phpunit.xml
+coverage.xml

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,9 @@ language: php
 dist: trusty
 
 php:
-  - 5.4
-  - 5.5
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
   - 7.3
-  - hhvm-3.12
-  - hhvm-3.18
-  - hhvm-3.24
-  - hhvm-3.27
   - nightly
 
 matrix:
@@ -21,15 +13,12 @@ matrix:
   allow_failures:
     - php: nightly
   include:
-    - dist: precise
-      php: 5.3
     - php: 7.1
       env: DOCS=yes
 
 sudo: false
 
 install:
-  - if [ $(php -r "echo PHP_MAJOR_VERSION;") -lt 7 ] ; then sed -i '/sami/D' composer.json ; fi
   - composer install
 
 after_success:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
-# Version 4.1
- 
+# Version 5.0
+
 * Released on N/A
+* Drop support for PHP 5.3, PHP 5.4, PHP 5.5, PHP 5.6, PHP 7.0 and HHVM
 
 # Version 4.0
 

--- a/composer.json
+++ b/composer.json
@@ -16,13 +16,13 @@
         "source": "https://github.com/phpmyadmin/motranslator"
     },
     "require": {
-        "php": ">=5.3.0",
-        "symfony/expression-language": "^4.0 || ^3.2 || ^2.8"
+        "php": "^7.1",
+        "symfony/expression-language": "^4.0"
     },
     "require-dev": {
         "sami/sami": "^4.0",
         "phpunit/php-code-coverage": "*",
-        "phpunit/phpunit": "~4.8 || ~5.7 || ~6.5"
+        "phpunit/phpunit": "^7.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -9,8 +9,7 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false"
-         syntaxCheck="false">
+         stopOnFailure="false">
     <logging>
         <log type="coverage-clover" target="coverage.xml" />
     </logging>


### PR DESCRIPTION
Drop support for PHP 5.3, PHP 5.4, PHP 5.5, PHP 5.6, PHP 7.0 and HHVM

Since phpMyAdmin requires PHP 7.1, it makes sense to require PHP 7.1 for motranslator as well.