### PR TITLE
Allow PHPUnit 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "require-dev": {
         "sami/sami": "^4.0",
         "phpunit/php-code-coverage": "*",
-        "phpunit/phpunit": "^7.4 || ^8",
+        "phpunit/phpunit": "^7.4 || ^8 || ^9",
         "phpmyadmin/coding-standard": "^1.0"
     },
     "autoload": {


### PR DESCRIPTION
```
PHPUnit 9.0.1 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.4RC1
Configuration: /dev/shm/BUILD/motranslator-d1982c7e468df332b6ff0d73fb599519140d393f/phpunit.xml.dist

................................................................. 65 / 76 ( 85%)
...........                                                       76 / 76 (100%)

Time: 76 ms, Memory: 6.00 MB

OK (76 tests, 143 assertions)

```