### PR TITLE
Add ability to use APCu for translation cache

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,6 +15,7 @@ jobs:
         strategy:
             matrix:
                 php-version: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
+                apcu-enable-cli: ["1", "0"]
                 os: [ubuntu-latest]
                 experimental: [false]
                 composer-options: ['']
@@ -27,7 +28,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php-version }}
                   extensions: apcu, mbstring
-                  ini_values: apc.enable_cli=1
+                  ini_values: apc.enable_cli=${{ matrix.apcu-enable-cli }}
                   coverage: xdebug
             - name: Get Composer Cache Directory
               id: composer-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             matrix:
                 php-version: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
-                extensions: ["mbstring", "apcu, mbstring"]
+                extensions: [":apcu, mbstring", "apcu, mbstring"]
                 os: [ubuntu-latest]
                 experimental: [false]
                 composer-options: ['']

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,7 @@ jobs:
               with:
                   php-version: ${{ matrix.php-version }}
                   extensions: apcu, mbstring
+                  ini_values: apc.enable_cli=1
                   coverage: xdebug
             - name: Get Composer Cache Directory
               id: composer-cache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-version }}
-                  extensions: mbstring
+                  extensions: apcu, mbstring
                   coverage: xdebug
             - name: Cache module
               uses: actions/cache@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
         strategy:
             matrix:
                 php-version: ["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]
-                apcu-enable-cli: ["1", "0"]
+                extensions: ["mbstring", "apcu, mbstring"]
                 os: [ubuntu-latest]
                 experimental: [false]
                 composer-options: ['']
@@ -27,8 +27,8 @@ jobs:
               uses: shivammathur/setup-php@v2
               with:
                   php-version: ${{ matrix.php-version }}
-                  extensions: apcu, mbstring
-                  ini_values: apc.enable_cli=${{ matrix.apcu-enable-cli }}
+                  extensions: ${{ matrix.extensions }}
+                  ini-values: "apc.enable_cli=1"
                   coverage: xdebug
             - name: Get Composer Cache Directory
               id: composer-cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+* Split out `.mo` parsing to separate `MoParser` class
+* Added `CacheInterface` so alternate cache implementations are pluggable
+* Added `ApcuCache` implementation to leverage shared in-memory translation cache
+
 ## [5.2.0] - 2021-02-05
 
 * Fix "Translator::selectString() must be of the type integer, boolean returned" (#37)

--- a/PERFORMANCE.md
+++ b/PERFORMANCE.md
@@ -9,6 +9,7 @@ There are two benchmark scripts in the code:
 * ``benchmark-context.php`` - benchmarks context usage
 * ``benchmark-plural.php`` - benchmarks plural evaluation
 * ``benchmark.php`` - benchmarks file parsing
+* ``benchmark-apcu.php`` - benchmarks file parsing with APCu cache enabled
 
 ## Performance measurements
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,14 @@ $cache = new PhpMyAdmin\MoTranslator\Cache\ApcuCache(
 $translator = new PhpMyAdmin\MoTranslator\Translator($cache);
 ```
 
+If you receive updated translation files you can load them without restarting the server using the low-level API:
+
+```php
+$parser = new PhpMyAdmin\MoTranslator\MoParser('./path/to/file.mo');
+$cache = new PhpMyAdmin\MoTranslator\Cache\ApcuCache($parser, 'de_DE', 'phpmyadmin');
+$parser->parseIntoCache($cache);
+```
+
 You should ensure APCu has enough memory to store all your translations, along with any other entries you use it 
 for. If an entry is evicted from cache, the `.mo` file will be re-parsed, impacting performance. See the 
 `apc.shm_size` and `apc.shm_segments` [documentation][6] and monitor cache usage when first rolling out.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Translation API for PHP using Gettext MO files.
 
 ## Limitations
 
-* Not suitable for huge MO files which you don't want to store in memory
+* Default `InMemoryCache` not suitable for huge MO files which you don't want to store in memory
 * Input and output encoding has to match (preferably UTF-8)
 
 ## Installation
@@ -58,7 +58,8 @@ $translator = $loader->getTranslator();
 ```php
 // Directly load the mo file
 // You can use null to not load a file and the use a setter to set the translations
-$translator = new PhpMyAdmin\MoTranslator\Translator('./path/to/file.mo');
+$cache = new PhpMyAdmin\MoTranslator\Cache\InMemoryCache(new PhpMyAdmin\MoTranslator\MoParser('./path/to/file.mo'));
+$translator = new PhpMyAdmin\MoTranslator\Translator($cache);
 
 // Now you can use Translator API (see below)
 ```

--- a/benchmark-apcu.php
+++ b/benchmark-apcu.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+require './vendor/autoload.php';
+
+$files = [
+    'big' => './tests/data/big.mo',
+    'little' => './tests/data/little.mo',
+];
+
+$start = microtime(true);
+
+for ($i = 0; $i < 2000; ++$i) {
+    foreach ($files as $domain => $filename) {
+        $translator = new PhpMyAdmin\MoTranslator\Translator(
+            new PhpMyAdmin\MoTranslator\Cache\ApcuCache(
+                new PhpMyAdmin\MoTranslator\MoParser($filename), 'foo', $domain
+            )
+        );
+        $translator->gettext('Column');
+    }
+}
+
+$end = microtime(true);
+
+$diff = $end - $start;
+
+echo 'Execution took ' . $diff . ' seconds' . "\n";

--- a/benchmark-context.php
+++ b/benchmark-context.php
@@ -12,9 +12,11 @@ $files = [
 $start = microtime(true);
 
 foreach ($files as $filename) {
-    $parser = new PhpMyAdmin\MoTranslator\Translator($filename);
+    $translator = new PhpMyAdmin\MoTranslator\Translator(
+        new PhpMyAdmin\MoTranslator\Cache\InMemoryCache(new PhpMyAdmin\MoTranslator\MoParser($filename))
+    );
     for ($i = 0; $i < 200000; ++$i) {
-        $parser->pgettext('Display format', 'Table');
+        $translator->pgettext('Display format', 'Table');
     }
 }
 

--- a/benchmark-plural.php
+++ b/benchmark-plural.php
@@ -12,10 +12,12 @@ $files = [
 $start = microtime(true);
 
 foreach ($files as $filename) {
-    $parser = new PhpMyAdmin\MoTranslator\Translator($filename);
+    $translator = new PhpMyAdmin\MoTranslator\Translator(
+        new PhpMyAdmin\MoTranslator\Cache\InMemoryCache(new PhpMyAdmin\MoTranslator\MoParser($filename))
+    );
     for ($i = 0; $i < 20000; ++$i) {
-        $parser->ngettext('%d second', '%d seconds', 10);
-        $parser->ngettext('%d second', '%d seconds', 1);
+        $translator->ngettext('%d second', '%d seconds', 10);
+        $translator->ngettext('%d second', '%d seconds', 1);
     }
 }
 

--- a/benchmark.php
+++ b/benchmark.php
@@ -13,8 +13,10 @@ $start = microtime(true);
 
 for ($i = 0; $i < 2000; ++$i) {
     foreach ($files as $filename) {
-        $parser = new PhpMyAdmin\MoTranslator\Translator($filename);
-        $parser->gettext('Column');
+        $translator = new PhpMyAdmin\MoTranslator\Translator(
+            new PhpMyAdmin\MoTranslator\Cache\InMemoryCache(new PhpMyAdmin\MoTranslator\MoParser($filename))
+        );
+        $translator->gettext('Column');
     }
 }
 

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,6 @@
         "symfony/expression-language": "^4.0 || ^5.0 || ^6.0"
     },
     "require-dev": {
-        "ext-apcu": "*",
         "phpunit/phpunit": "^7.4 || ^8 || ^9",
         "phpmyadmin/coding-standard": "^3.0.0",
         "phpstan/phpstan": "^1.4.6"

--- a/composer.json
+++ b/composer.json
@@ -31,6 +31,7 @@
         "symfony/expression-language": "^4.0 || ^5.0"
     },
     "require-dev": {
+        "ext-apcu": "*",
         "phpunit/phpunit": "^7.4 || ^8 || ^9",
         "phpmyadmin/coding-standard": "^3.0.0",
         "phpstan/phpstan": "^0.12.56"
@@ -44,5 +45,8 @@
         "psr-4": {
             "PhpMyAdmin\\MoTranslator\\Tests\\": "tests"
         }
+    },
+    "suggest": {
+        "ext-apcu": "Needed for ACPu-backed translation cache"
     }
 }

--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -113,7 +113,7 @@ final class ApcuCache implements CacheInterface
         $key = $this->getKey(self::LOADED_KEY);
         $loaded = apcu_exists($key) || apcu_entry($key, static function (): int {
             return 0;
-        });
+        }, $this->ttl);
         if ($loaded) {
             return;
         }

--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -76,7 +76,7 @@ final class ApcuCache implements CacheInterface
     private function reloadOnMiss(string $msgid): string
     {
         // store original if translation is not present
-        $cached = apcu_entry($msgid, static function () use ($msgid) {
+        $cached = apcu_entry($this->getKey($msgid), static function () use ($msgid) {
             return $msgid;
         }, $this->ttl);
         // if another process has updated cache, return early

--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -18,6 +18,7 @@ use function array_map;
 use function assert;
 use function function_exists;
 use function is_array;
+use function is_string;
 
 final class ApcuCache implements CacheInterface
 {
@@ -64,7 +65,7 @@ final class ApcuCache implements CacheInterface
     public function get(string $msgid): string
     {
         $msgstr = apcu_fetch($this->getKey($msgid), $success);
-        if ($success) {
+        if ($success && is_string($msgstr)) {
             return $msgstr;
         }
 
@@ -79,7 +80,7 @@ final class ApcuCache implements CacheInterface
 
         $msgstr = apcu_fetch($this->getKey($msgid), $success);
 
-        return $success ? $msgstr : $msgid;
+        return $success && is_string($msgstr) ? $msgstr : $msgid;
     }
 
     public function set(string $msgid, string $msgstr): void

--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -45,12 +45,9 @@ final class ApcuCache implements CacheInterface
         bool $reloadOnMiss = true,
         string $prefix = 'mo_'
     ) {
-        // @codeCoverageIgnoreStart
         if (! (function_exists('apcu_enabled') && apcu_enabled())) {
             throw new CacheException('ACPu extension must be installed and enabled');
         }
-
-        // @codeCoverageIgnoreEnd
 
         $this->parser = $parser;
         $this->locale = $locale;

--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Cache;
+
+use PhpMyAdmin\MoTranslator\CacheException;
+use PhpMyAdmin\MoTranslator\MoParser;
+
+use function apcu_enabled;
+use function apcu_entry;
+use function apcu_exists;
+use function apcu_fetch;
+use function apcu_store;
+use function array_combine;
+use function array_keys;
+use function array_map;
+use function assert;
+use function function_exists;
+use function is_array;
+
+final class ApcuCache implements CacheInterface
+{
+    public const LOADED_KEY = '__TRANSLATIONS_LOADED__';
+
+    /** @var MoParser */
+    private $parser;
+    /** @var string */
+    private $locale;
+    /** @var string */
+    private $domain;
+    /** @var int */
+    private $ttl;
+    /** @var bool */
+    private $reloadOnMiss;
+    /** @var string */
+    private $prefix;
+
+    public function __construct(
+        MoParser $parser,
+        string $locale,
+        string $domain,
+        int $ttl = 0,
+        bool $reloadOnMiss = true,
+        string $prefix = 'mo_'
+    ) {
+        // @codeCoverageIgnoreStart
+        if (! (function_exists('apcu_enabled') && apcu_enabled())) {
+            throw new CacheException('ACPu extension must be installed and enabled');
+        }
+
+        // @codeCoverageIgnoreEnd
+
+        $this->parser = $parser;
+        $this->locale = $locale;
+        $this->domain = $domain;
+        $this->ttl = $ttl;
+        $this->reloadOnMiss = $reloadOnMiss;
+        $this->prefix = $prefix;
+
+        $this->ensureTranslationsLoaded();
+    }
+
+    public function get(string $msgid): string
+    {
+        $msgstr = apcu_fetch($this->getKey($msgid), $success);
+        if ($success) {
+            return $msgstr;
+        }
+
+        if (! $this->reloadOnMiss) {
+            return $msgid;
+        }
+
+        // store original in case translation is not present
+        apcu_store($msgid, $msgid);
+        // reload .mo file, in case entry has been evicted
+        $this->parser->parseIntoCache($this);
+
+        $msgstr = apcu_fetch($this->getKey($msgid), $success);
+
+        return $success ? $msgstr : $msgid;
+    }
+
+    public function set(string $msgid, string $msgstr): void
+    {
+        apcu_store($this->getKey($msgid), $msgstr, $this->ttl);
+    }
+
+    public function has(string $msgid): bool
+    {
+        return apcu_exists($this->getKey($msgid));
+    }
+
+    public function setAll(array $translations): void
+    {
+        $keys = array_map(function (string $msgid): string {
+            return $this->getKey($msgid);
+        }, array_keys($translations));
+        $translations = array_combine($keys, $translations);
+        assert(is_array($translations));
+
+        apcu_store($translations, null, $this->ttl);
+    }
+
+    private function getKey(string $msgid): string
+    {
+        return $this->prefix . $this->locale . '.' . $this->domain . '.' . $msgid;
+    }
+
+    private function ensureTranslationsLoaded(): void
+    {
+        // Try to prevent cache slam if multiple processes are trying to load translations. There is still a race
+        // between the exists check and creating the entry, but at least it's small
+        $key = $this->getKey(self::LOADED_KEY);
+        $loaded = apcu_exists($key) || apcu_entry($key, static function (): int {
+            return 0;
+        });
+        if ($loaded) {
+            return;
+        }
+
+        $this->parser->parseIntoCache($this);
+        apcu_store($this->getKey(self::LOADED_KEY), 1, $this->ttl);
+    }
+}

--- a/src/Cache/ApcuCacheFactory.php
+++ b/src/Cache/ApcuCacheFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Cache;
+
+use PhpMyAdmin\MoTranslator\MoParser;
+
+final class ApcuCacheFactory implements CacheFactoryInterface
+{
+    /** @var int */
+    private $ttl;
+    /** @var bool */
+    private $reloadOnMiss;
+    /** @var string */
+    private $prefix;
+
+    public function __construct(int $ttl = 0, bool $reloadOnMiss = true, string $prefix = 'mo_')
+    {
+        $this->ttl = $ttl;
+        $this->reloadOnMiss = $reloadOnMiss;
+        $this->prefix = $prefix;
+    }
+
+    public function getInstance(MoParser $parser, string $locale, string $domain): CacheInterface
+    {
+        return new ApcuCache($parser, $locale, $domain, $this->ttl, $this->reloadOnMiss, $this->prefix);
+    }
+}

--- a/src/Cache/CacheFactoryInterface.php
+++ b/src/Cache/CacheFactoryInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Cache;
+
+use PhpMyAdmin\MoTranslator\MoParser;
+
+interface CacheFactoryInterface
+{
+    public function getInstance(MoParser $parser, string $locale, string $domain): CacheInterface;
+}

--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Cache;
+
+interface CacheInterface
+{
+    /**
+     * Returns cached `msgstr` if it is in cache, otherwise `$msgid`
+     */
+    public function get(string $msgid): string;
+
+    /**
+     * Caches `$msgstr` value for key `$mesid`
+     */
+    public function set(string $msgid, string $msgstr): void;
+
+    /**
+     * Returns true if cache has entry for `$msgid`
+     */
+    public function has(string $msgid): bool;
+
+    /**
+     * Populates cache with array of `$msgid => $msgstr` entries
+     *
+     * This will overwrite existing values for `$msgid`, but is not guaranteed to clear cache of existing entries
+     * not present in `$translations`.
+     *
+     * @param array<string, string> $translations
+     */
+    public function setAll(array $translations): void;
+}

--- a/src/Cache/GetAllInterface.php
+++ b/src/Cache/GetAllInterface.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Cache;
+
+interface GetAllInterface
+{
+    /**
+     * @return array<string, string>
+     */
+    public function getAll(): array;
+}

--- a/src/Cache/InMemoryCache.php
+++ b/src/Cache/InMemoryCache.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Cache;
+
+use PhpMyAdmin\MoTranslator\MoParser;
+
+use function array_key_exists;
+
+final class InMemoryCache implements CacheInterface, GetAllInterface
+{
+    /** @var array<string, string> */
+    private $cache;
+
+    public function __construct(MoParser $parser)
+    {
+        $this->cache = [];
+        $parser->parseIntoCache($this);
+    }
+
+    public function get(string $msgid): string
+    {
+        return array_key_exists($msgid, $this->cache) ? $this->cache[$msgid] : $msgid;
+    }
+
+    public function set(string $msgid, string $msgstr): void
+    {
+        $this->cache[$msgid] = $msgstr;
+    }
+
+    public function has(string $msgid): bool
+    {
+        return array_key_exists($msgid, $this->cache);
+    }
+
+    public function setAll(array $translations): void
+    {
+        $this->cache = $translations;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAll(): array
+    {
+        return $this->cache;
+    }
+}

--- a/src/CacheException.php
+++ b/src/CacheException.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator;
+
+use DomainException;
+
+final class CacheException extends DomainException
+{
+}

--- a/src/Loader.php
+++ b/src/Loader.php
@@ -26,6 +26,9 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\MoTranslator;
 
+use PhpMyAdmin\MoTranslator\Cache\CacheFactoryInterface;
+use PhpMyAdmin\MoTranslator\Cache\InMemoryCache;
+
 use function array_push;
 use function file_exists;
 use function getenv;
@@ -42,6 +45,14 @@ class Loader
      * @var Loader
      */
     private static $instance;
+
+    /**
+     * Factory to return a factory responsible for returning a `CacheInterface`
+     *
+     * @static
+     * @var CacheFactoryInterface|null
+     */
+    private static $cacheFactory = null;
 
     /**
      * Default gettext domain to use.
@@ -180,6 +191,14 @@ class Loader
     }
 
     /**
+     * Sets factory responsible for composing a `CacheInterface`
+     */
+    public static function setCacheFactory(?CacheFactoryInterface $cacheFactory): void
+    {
+        self::$cacheFactory = $cacheFactory;
+    }
+
+    /**
      * Returns Translator object for domain or for default domain.
      *
      * @param string $domain Translation domain
@@ -213,7 +232,14 @@ class Loader
 
             // We don't care about invalid path, we will get fallback
             // translator here
-            $this->domains[$this->locale][$domain] = new Translator($filename);
+            $moParser = new MoParser($filename);
+            if (self::$cacheFactory instanceof CacheFactoryInterface) {
+                $cache = self::$cacheFactory->getInstance($moParser, $this->locale, $domain);
+            } else {
+                $cache = new InMemoryCache($moParser);
+            }
+
+            $this->domains[$this->locale][$domain] = new Translator($cache);
         }
 
         return $this->domains[$this->locale][$domain];

--- a/src/MoParser.php
+++ b/src/MoParser.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator;
+
+use PhpMyAdmin\MoTranslator\Cache\CacheInterface;
+
+use function is_readable;
+use function strcmp;
+
+final class MoParser
+{
+    /**
+     * None error.
+     */
+    public const ERROR_NONE = 0;
+    /**
+     * File does not exist.
+     */
+    public const ERROR_DOES_NOT_EXIST = 1;
+    /**
+     * File has bad magic number.
+     */
+    public const ERROR_BAD_MAGIC = 2;
+    /**
+     * Error while reading file, probably too short.
+     */
+    public const ERROR_READING = 3;
+
+    /**
+     * Big endian mo file magic bytes.
+     */
+    public const MAGIC_BE = "\x95\x04\x12\xde";
+    /**
+     * Little endian mo file magic bytes.
+     */
+    public const MAGIC_LE = "\xde\x12\x04\x95";
+
+    /**
+     * Parse error code (0 if no error).
+     *
+     * @var int
+     */
+    public $error = self::ERROR_NONE;
+
+    /** @var string|null */
+    private $filename;
+
+    public function __construct(?string $filename)
+    {
+        $this->filename = $filename;
+    }
+
+    /**
+     * Parses .mo file and stores results to `$cache`
+     */
+    public function parseIntoCache(CacheInterface $cache): void
+    {
+        if ($this->filename === null) {
+            return;
+        }
+
+        if (! is_readable($this->filename)) {
+            $this->error = self::ERROR_DOES_NOT_EXIST;
+
+            return;
+        }
+
+        $stream = new StringReader($this->filename);
+
+        try {
+            $magic = $stream->read(0, 4);
+            if (strcmp($magic, self::MAGIC_LE) === 0) {
+                $unpack = 'V';
+            } elseif (strcmp($magic, self::MAGIC_BE) === 0) {
+                $unpack = 'N';
+            } else {
+                $this->error = self::ERROR_BAD_MAGIC;
+
+                return;
+            }
+
+            /* Parse header */
+            $total = $stream->readint($unpack, 8);
+            $originals = $stream->readint($unpack, 12);
+            $translations = $stream->readint($unpack, 16);
+
+            /* get original and translations tables */
+            $totalTimesTwo = (int) ($total * 2);// Fix for issue #36 on ARM
+            $tableOriginals = $stream->readintarray($unpack, $originals, $totalTimesTwo);
+            $tableTranslations = $stream->readintarray($unpack, $translations, $totalTimesTwo);
+
+            /* read all strings to the cache */
+            for ($i = 0; $i < $total; ++$i) {
+                $iTimesTwo = $i * 2;
+                $iPlusOne = $iTimesTwo + 1;
+                $iPlusTwo = $iTimesTwo + 2;
+                $original = $stream->read($tableOriginals[$iPlusTwo], $tableOriginals[$iPlusOne]);
+                $translation = $stream->read($tableTranslations[$iPlusTwo], $tableTranslations[$iPlusOne]);
+                $cache->set($original, $translation);
+            }
+        } catch (ReaderException $e) {
+            $this->error = self::ERROR_READING;
+
+            return;
+        }
+    }
+}

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -107,7 +107,7 @@ class Translator
     private $cache;
 
     /**
-     * @param CacheInterface|string|null $cache
+     * @param CacheInterface|string|null $cache Name of mo file to load (null to not load a file) or a CacheInterface implementation
      */
     public function __construct($cache)
     {

--- a/src/Translator.php
+++ b/src/Translator.php
@@ -28,6 +28,7 @@ namespace PhpMyAdmin\MoTranslator;
 
 use PhpMyAdmin\MoTranslator\Cache\CacheInterface;
 use PhpMyAdmin\MoTranslator\Cache\GetAllInterface;
+use PhpMyAdmin\MoTranslator\Cache\InMemoryCache;
 use Symfony\Component\ExpressionLanguage\ExpressionLanguage;
 use Throwable;
 
@@ -105,8 +106,15 @@ class Translator
     /** @var CacheInterface */
     private $cache;
 
-    public function __construct(CacheInterface $cache)
+    /**
+     * @param CacheInterface|string|null $cache
+     */
+    public function __construct($cache)
     {
+        if (! $cache instanceof CacheInterface) {
+            $cache = new InMemoryCache(new MoParser($cache));
+        }
+
         $this->cache = $cache;
     }
 

--- a/tests/Cache/ApcuCacheFactoryTest.php
+++ b/tests/Cache/ApcuCacheFactoryTest.php
@@ -16,6 +16,9 @@ use function apcu_fetch;
 use function function_exists;
 use function sleep;
 
+/**
+ * @covers \PhpMyAdmin\MoTranslator\Cache\ApcuCacheFactory
+ */
 class ApcuCacheFactoryTest extends TestCase
 {
     protected function setUp(): void

--- a/tests/Cache/ApcuCacheFactoryTest.php
+++ b/tests/Cache/ApcuCacheFactoryTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Tests\Cache;
+
+use PhpMyAdmin\MoTranslator\Cache\ApcuCache;
+use PhpMyAdmin\MoTranslator\Cache\ApcuCacheFactory;
+use PhpMyAdmin\MoTranslator\MoParser;
+use PHPUnit\Framework\TestCase;
+
+use function apcu_clear_cache;
+use function apcu_delete;
+use function apcu_enabled;
+use function apcu_fetch;
+use function function_exists;
+use function sleep;
+
+class ApcuCacheFactoryTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (function_exists('apcu_enabled') && apcu_enabled()) {
+            return;
+        }
+
+        $this->markTestSkipped('ACPu extension is not installed and enabled for CLI');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        apcu_clear_cache();
+    }
+
+    public function testGetInstanceReturnApcuCache(): void
+    {
+        $factory = new ApcuCacheFactory();
+        $instance = $factory->getInstance(new MoParser(null), 'foo', 'bar');
+        $this->assertInstanceOf(ApcuCache::class, $instance);
+    }
+
+    public function testConstructorSetsTtl(): void
+    {
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+        $ttl = 1;
+
+        $factory = new ApcuCacheFactory($ttl);
+        $parser = new MoParser(__DIR__ . '/../data/little.mo');
+        $factory->getInstance($parser, $locale, $domain);
+        sleep($ttl * 2);
+
+        apcu_fetch('mo_' . $locale . '.' . $domain . '.' . $msgid, $success);
+        $this->assertFalse($success);
+    }
+
+    public function testConstructorSetsReloadOnMiss(): void
+    {
+        $expected = 'Column';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+
+        $factory = new ApcuCacheFactory(0, false);
+        $parser = new MoParser(__DIR__ . '/../data/little.mo');
+
+        $instance = $factory->getInstance($parser, $locale, $domain);
+
+        apcu_delete('mo_' . $locale . '.' . $domain . '.' . $msgid);
+        $actual = $instance->get($msgid);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testConstructorSetsPrefix(): void
+    {
+        $expected = 'Pole';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+        $prefix = 'baz_';
+
+        $factory = new ApcuCacheFactory(0, true, $prefix);
+        $parser = new MoParser(__DIR__ . '/../data/little.mo');
+
+        $factory->getInstance($parser, $locale, $domain);
+
+        $actual = apcu_fetch($prefix . $locale . '.' . $domain . '.' . $msgid);
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/Cache/ApcuCacheTest.php
+++ b/tests/Cache/ApcuCacheTest.php
@@ -64,6 +64,8 @@ class ApcuCacheTest extends TestCase
 
         apcu_fetch('mo_' . $locale . '.' . $domain . '.' . $msgid, $success);
         $this->assertFalse($success);
+        apcu_fetch('mo_' . $locale . '.' . $domain . '.' . ApcuCache::LOADED_KEY, $success);
+        $this->assertFalse($success);
     }
 
     public function testConstructorSetsReloadOnMiss(): void

--- a/tests/Cache/ApcuCacheTest.php
+++ b/tests/Cache/ApcuCacheTest.php
@@ -162,6 +162,19 @@ class ApcuCacheTest extends TestCase
         $this->assertSame($expected, $actual);
     }
 
+    public function testStoresMsgidOnCacheMiss(): void
+    {
+        $expected = 'Column';
+        $locale = 'foo';
+        $domain = 'bar';
+
+        $cache = new ApcuCache(new MoParser(null), $locale, $domain);
+        $cache->get($expected);
+
+        $actual = apcu_fetch('mo_' . $locale . '.' . $domain . '.' . $expected);
+        $this->assertSame($expected, $actual);
+    }
+
     public function testGetReloadsOnCacheMiss(): void
     {
         $expected = 'Pole';
@@ -188,7 +201,8 @@ class ApcuCacheTest extends TestCase
         $method = new ReflectionMethod($cache, 'reloadOnMiss');
         $method->setAccessible(true);
 
-        apcu_entry($msgid, static function () use ($expected): string {
+        $key = 'mo_' . $locale . '.' . $domain . '.' . $msgid;
+        apcu_entry($key, static function () use ($expected): string {
             sleep(1);
 
             return $expected;

--- a/tests/Cache/ApcuCacheTest.php
+++ b/tests/Cache/ApcuCacheTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Tests\Cache;
+
+use PhpMyAdmin\MoTranslator\Cache\ApcuCache;
+use PhpMyAdmin\MoTranslator\MoParser;
+use PHPUnit\Framework\TestCase;
+
+use function apcu_clear_cache;
+use function apcu_delete;
+use function apcu_enabled;
+use function apcu_fetch;
+use function function_exists;
+use function sleep;
+
+/**
+ * @covers \PhpMyAdmin\MoTranslator\Cache\ApcuCache
+ */
+class ApcuCacheTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (function_exists('apcu_enabled') && apcu_enabled()) {
+            return;
+        }
+
+        $this->markTestSkipped('ACPu extension is not installed and enabled for CLI');
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        apcu_clear_cache();
+    }
+
+    public function testConstructorLoadsCache(): void
+    {
+        $expected = 'Pole';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+
+        new ApcuCache(new MoParser(__DIR__ . '/../data/little.mo'), $locale, $domain);
+
+        $actual = apcu_fetch('mo_' . $locale . '.' . $domain . '.' . $msgid);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testConstructorSetsTtl(): void
+    {
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+        $ttl = 1;
+
+        new ApcuCache(new MoParser(__DIR__ . '/../data/little.mo'), $locale, $domain, $ttl);
+        sleep($ttl * 2);
+
+        apcu_fetch('mo_' . $locale . '.' . $domain . '.' . $msgid, $success);
+        $this->assertFalse($success);
+    }
+
+    public function testConstructorSetsReloadOnMiss(): void
+    {
+        $expected = 'Column';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+        $prefix = 'baz_';
+
+        $cache = new ApcuCache(
+            new MoParser(__DIR__ . '/../data/little.mo'),
+            $locale,
+            $domain,
+            0,
+            false,
+            $prefix
+        );
+
+        apcu_delete($prefix . $locale . '.' . $domain . '.' . $msgid);
+        $actual = $cache->get($msgid);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testConstructorSetsPrefix(): void
+    {
+        $expected = 'Pole';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+        $prefix = 'baz_';
+
+        new ApcuCache(new MoParser(__DIR__ . '/../data/little.mo'), $locale, $domain, 0, true, $prefix);
+
+        $actual = apcu_fetch($prefix . $locale . '.' . $domain . '.' . $msgid);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testEnsureTranslationsLoadedSetsLoadedKey(): void
+    {
+        $expected = 1;
+        $locale = 'foo';
+        $domain = 'bar';
+
+        new ApcuCache(new MoParser(__DIR__ . '/../data/little.mo'), $locale, $domain);
+
+        $actual = apcu_fetch('mo_' . $locale . '.' . $domain . '.' . ApcuCache::LOADED_KEY);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testGetReturnsMsgstr(): void
+    {
+        $expected = 'Pole';
+        $msgid = 'Column';
+
+        $cache = new ApcuCache(new MoParser(__DIR__ . '/../data/little.mo'), 'foo', 'bar');
+
+        $actual = $cache->get($msgid);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testGetReturnsMsgidForCacheMiss(): void
+    {
+        $expected = 'Column';
+
+        $cache = new ApcuCache(new MoParser(null), 'foo', 'bar');
+
+        $actual = $cache->get($expected);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testGetReloadsOnCacheMiss(): void
+    {
+        $expected = 'Pole';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+
+        $cache = new ApcuCache(new MoParser(__DIR__ . '/../data/little.mo'), 'foo', 'bar');
+
+        apcu_delete('mo_' . $locale . '.' . $domain . '.' . ApcuCache::LOADED_KEY);
+        $actual = $cache->get($msgid);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testSetSetsMsgstr(): void
+    {
+        $expected = 'Pole';
+        $msgid = 'Column';
+
+        $cache = new ApcuCache(new MoParser(null), 'foo', 'bar');
+        $cache->set($msgid, $expected);
+
+        $actual = $cache->get($msgid);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testHasReturnsFalse(): void
+    {
+        $cache = new ApcuCache(new MoParser(null), 'foo', 'bar');
+        $actual = $cache->has('Column');
+        $this->assertFalse($actual);
+    }
+
+    public function testHasReturnsTrue(): void
+    {
+        $cache = new ApcuCache(new MoParser(__DIR__ . '/../data/little.mo'), 'foo', 'bar');
+        $actual = $cache->has('Column');
+        $this->assertTrue($actual);
+    }
+
+    public function testSetAllSetsTranslations(): void
+    {
+        $translations = [
+            'foo' => 'bar',
+            'and' => 'another',
+        ];
+
+        $cache = new ApcuCache(new MoParser(null), 'foo', 'bar');
+        $cache->setAll($translations);
+
+        foreach ($translations as $msgid => $expected) {
+            $actual = $cache->get($msgid);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+}

--- a/tests/Cache/ApcuDisabledTest.php
+++ b/tests/Cache/ApcuDisabledTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Tests\Cache;
+
+use PhpMyAdmin\MoTranslator\Cache\ApcuCache;
+use PhpMyAdmin\MoTranslator\CacheException;
+use PhpMyAdmin\MoTranslator\MoParser;
+use PHPUnit\Framework\TestCase;
+
+use function apcu_enabled;
+use function function_exists;
+
+final class ApcuDisabledTest extends TestCase
+{
+    public function testConstructorApcuNotEnabledThrowsException(): void
+    {
+        if (function_exists('apcu_enabled') && apcu_enabled()) {
+            $this->markTestSkipped('ext-apcu is enabled');
+        }
+
+        $this->expectException(CacheException::class);
+        new ApcuCache(new MoParser(null), 'foo', 'bar');
+    }
+}

--- a/tests/Cache/ApcuDisabledTest.php
+++ b/tests/Cache/ApcuDisabledTest.php
@@ -21,6 +21,7 @@ final class ApcuDisabledTest extends TestCase
         }
 
         $this->expectException(CacheException::class);
+        $this->expectExceptionMessage('ACPu extension must be installed and enabled');
         new ApcuCache(new MoParser(null), 'foo', 'bar');
     }
 }

--- a/tests/Cache/InMemoryCacheTest.php
+++ b/tests/Cache/InMemoryCacheTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Tests\Cache;
+
+use PhpMyAdmin\MoTranslator\Cache\InMemoryCache;
+use PhpMyAdmin\MoTranslator\MoParser;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \PhpMyAdmin\MoTranslator\Cache\InMemoryCache
+ */
+class InMemoryCacheTest extends TestCase
+{
+    public function testConstructorParsesCache(): void
+    {
+        $expected = 'Pole';
+        $parser = new MoParser(__DIR__ . '/../data/little.mo');
+        $cache = new InMemoryCache($parser);
+        $actual = $cache->get('Column');
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testGetReturnsMsgidForCacheMiss(): void
+    {
+        $expected = 'Column';
+        $cache = new InMemoryCache(new MoParser(null));
+        $actual = $cache->get($expected);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testSetSetsMsgstr(): void
+    {
+        $expected = 'Pole';
+        $msgid = 'Column';
+        $cache = new InMemoryCache(new MoParser(null));
+        $cache->set($msgid, $expected);
+        $actual = $cache->get($msgid);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testHasReturnsFalse(): void
+    {
+        $cache = new InMemoryCache(new MoParser(null));
+        $actual = $cache->has('Column');
+        $this->assertFalse($actual);
+    }
+
+    public function testHasReturnsTrue(): void
+    {
+        $cache = new InMemoryCache(new MoParser(__DIR__ . '/../data/little.mo'));
+        $actual = $cache->has('Column');
+        $this->assertTrue($actual);
+    }
+
+    public function testSetAllSetsTranslations(): void
+    {
+        $translations = [
+            'foo' => 'bar',
+            'and' => 'another',
+        ];
+        $cache = new InMemoryCache(new MoParser(null));
+        $cache->setAll($translations);
+        foreach ($translations as $msgid => $expected) {
+            $actual = $cache->get($msgid);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    public function testGetAllReturnsTranslations(): void
+    {
+        $expected = [
+            'foo' => 'bar',
+            'and' => 'another',
+        ];
+        $cache = new InMemoryCache(new MoParser(null));
+        $cache->setAll($expected);
+        $actual = $cache->getAll();
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -302,7 +302,7 @@ class LoaderTest extends TestCase
         $locale = 'be_BY';
         $domain = 'apcu';
 
-        $cache = $this->createStub(CacheInterface::class);
+        $cache = $this->createMock(CacheInterface::class);
         $cache->method('get')
             ->willReturn($expected);
         $factory = $this->createMock(CacheFactoryInterface::class);

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -4,7 +4,10 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\MoTranslator\Tests;
 
+use PhpMyAdmin\MoTranslator\Cache\CacheFactoryInterface;
+use PhpMyAdmin\MoTranslator\Cache\CacheInterface;
 use PhpMyAdmin\MoTranslator\Loader;
+use PhpMyAdmin\MoTranslator\MoParser;
 use PHPUnit\Framework\TestCase;
 
 use function getenv;
@@ -291,5 +294,30 @@ class LoaderTest extends TestCase
             'en',
             $loader->detectlocale()
         );
+    }
+
+    public function testSetCacheFactory(): void
+    {
+        $expected = 'Foo';
+        $locale = 'be_BY';
+        $domain = 'apcu';
+
+        $cache = $this->createStub(CacheInterface::class);
+        $cache->method('get')
+            ->willReturn($expected);
+        $factory = $this->createMock(CacheFactoryInterface::class);
+        $factory->expects($this->once())
+            ->method('getInstance')
+            ->with($this->isInstanceOf(MoParser::class), $locale, $domain)
+            ->willReturn($cache);
+
+        $loader = Loader::getInstance();
+        $loader->setCacheFactory($factory);
+        $loader->setlocale($locale);
+        $loader->bindtextdomain($domain, __DIR__ . '/data/locale/');
+        $translator = $loader->getTranslator($domain);
+
+        $actual = $translator->gettext('Type');
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -8,6 +8,7 @@ use PhpMyAdmin\MoTranslator\Cache\CacheFactoryInterface;
 use PhpMyAdmin\MoTranslator\Cache\CacheInterface;
 use PhpMyAdmin\MoTranslator\Loader;
 use PhpMyAdmin\MoTranslator\MoParser;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 use function getenv;
@@ -305,6 +306,7 @@ class LoaderTest extends TestCase
         $cache = $this->createMock(CacheInterface::class);
         $cache->method('get')
             ->willReturn($expected);
+        /** @var CacheFactoryInterface&MockObject $factory */
         $factory = $this->createMock(CacheFactoryInterface::class);
         $factory->expects($this->once())
             ->method('getInstance')

--- a/tests/LoaderTest.php
+++ b/tests/LoaderTest.php
@@ -311,8 +311,8 @@ class LoaderTest extends TestCase
             ->with($this->isInstanceOf(MoParser::class), $locale, $domain)
             ->willReturn($cache);
 
+        Loader::setCacheFactory($factory);
         $loader = Loader::getInstance();
-        $loader->setCacheFactory($factory);
         $loader->setlocale($locale);
         $loader->bindtextdomain($domain, __DIR__ . '/data/locale/');
         $translator = $loader->getTranslator($domain);

--- a/tests/PluralTest.php
+++ b/tests/PluralTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\MoTranslator\Tests;
 
+use PhpMyAdmin\MoTranslator\Cache\InMemoryCache;
+use PhpMyAdmin\MoTranslator\MoParser;
 use PhpMyAdmin\MoTranslator\Translator;
 use PHPUnit\Framework\TestCase;
 
@@ -25,7 +27,7 @@ class PluralTest extends TestCase
      */
     public function testNpgettext(int $number, string $expected): void
     {
-        $parser = new Translator('');
+        $parser = $this->getTranslator('');
         $result = $parser->npgettext('context', "%d pig went to the market\n", "%d pigs went to the market\n", $number);
         $this->assertSame($expected, $result);
     }
@@ -54,7 +56,7 @@ class PluralTest extends TestCase
      */
     public function testNgettext(): void
     {
-        $parser = new Translator('');
+        $parser = $this->getTranslator('');
         $translationKey = implode(chr(0), ["%d pig went to the market\n", "%d pigs went to the market\n"]);
         $parser->setTranslation($translationKey, '');
         $result = $parser->ngettext("%d pig went to the market\n", "%d pigs went to the market\n", 1);
@@ -93,7 +95,7 @@ class PluralTest extends TestCase
      */
     public function testNgettextSelectString(string $pluralForms): void
     {
-        $parser = new Translator('');
+        $parser = $this->getTranslator('');
         $parser->setTranslation(
             '',
             "Project-Id-Version: phpMyAdmin 5.1.0-dev\n"
@@ -114,5 +116,10 @@ class PluralTest extends TestCase
         $parser->setTranslation($translationKey, 'ok');
         $result = $parser->ngettext("%d pig went to the market\n", "%d pigs went to the market\n", 1);
         $this->assertSame('ok', $result);
+    }
+
+    private function getTranslator(string $filename): Translator
+    {
+        return new Translator(new InMemoryCache(new MoParser($filename)));
     }
 }

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -4,9 +4,12 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\MoTranslator\Tests;
 
+use PhpMyAdmin\MoTranslator\Cache\CacheInterface;
 use PhpMyAdmin\MoTranslator\Cache\InMemoryCache;
+use PhpMyAdmin\MoTranslator\CacheException;
 use PhpMyAdmin\MoTranslator\MoParser;
 use PhpMyAdmin\MoTranslator\Translator;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -60,6 +63,16 @@ class TranslatorTest extends TestCase
         $translator->setTranslations($transTable);
         $this->assertSame($transTable, $translator->getTranslations());
         $this->assertEquals('it depends', $translator->gettext('is it hard'));
+    }
+
+    public function testGetTranslationsThrowsException(): void
+    {
+        /** @var CacheInterface&MockObject $cache */
+        $cache = $this->createMock(CacheInterface::class);
+        $translator = new Translator($cache);
+
+        $this->expectException(CacheException::class);
+        $translator->getTranslations();
     }
 
     private function getTranslator(?string $filename): Translator

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace PhpMyAdmin\MoTranslator\Tests;
 
+use PhpMyAdmin\MoTranslator\Cache\InMemoryCache;
+use PhpMyAdmin\MoTranslator\MoParser;
 use PhpMyAdmin\MoTranslator\Translator;
 use PHPUnit\Framework\TestCase;
 
@@ -17,7 +19,7 @@ class TranslatorTest extends TestCase
      */
     public function testGettext(): void
     {
-        $translator = new Translator('');
+        $translator = $this->getTranslator('');
         $this->assertEquals('Test', $translator->gettext('Test'));
     }
 
@@ -26,7 +28,7 @@ class TranslatorTest extends TestCase
      */
     public function testSetTranslation(): void
     {
-        $translator = new Translator('');
+        $translator = $this->getTranslator('');
         $translator->setTranslation('Test', 'Translation');
         $this->assertEquals('Translation', $translator->gettext('Test'));
     }
@@ -37,11 +39,11 @@ class TranslatorTest extends TestCase
     public function testGetSetTranslations(): void
     {
         $transTable = ['Test' => 'Translation'];
-        $translator = new Translator('');
+        $translator = $this->getTranslator('');
         $translator->setTranslations($transTable);
         $this->assertEquals('Translation', $translator->gettext('Test'));
         $this->assertSame($transTable, $translator->getTranslations());
-        $translator = new Translator(null);
+        $translator = $this->getTranslator(null);
         $translator->setTranslations($transTable);
         $this->assertSame($transTable, $translator->getTranslations());
         $this->assertEquals('Translation', $translator->gettext('Test'));
@@ -50,13 +52,18 @@ class TranslatorTest extends TestCase
             'shouldIWriteTests' => 'as much as possible',
             'is it hard' => 'it depends',
         ];
-        $translator = new Translator('');
+        $translator = $this->getTranslator('');
         $translator->setTranslations($transTable);
         $this->assertSame($transTable, $translator->getTranslations());
         $this->assertEquals('as much as possible', $translator->gettext('shouldIWriteTests'));
-        $translator = new Translator(null);
+        $translator = $this->getTranslator(null);
         $translator->setTranslations($transTable);
         $this->assertSame($transTable, $translator->getTranslations());
         $this->assertEquals('it depends', $translator->gettext('is it hard'));
+    }
+
+    private function getTranslator(?string $filename): Translator
+    {
+        return new Translator(new InMemoryCache(new MoParser($filename)));
     }
 }

--- a/tests/TranslatorTest.php
+++ b/tests/TranslatorTest.php
@@ -17,6 +17,22 @@ use PHPUnit\Framework\TestCase;
  */
 class TranslatorTest extends TestCase
 {
+    public function testConstructorWithFilenameParam(): void
+    {
+        $expected = 'Pole';
+        $translator = new Translator(__DIR__ . '/data/little.mo');
+        $actual = $translator->gettext('Column');
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testConstructorWithNullParam(): void
+    {
+        $expected = 'Column';
+        $translator = new Translator(null);
+        $actual = $translator->gettext($expected);
+        $this->assertSame($expected, $actual);
+    }
+
     /**
      * Test on empty gettext
      */


### PR DESCRIPTION
First off, thanks for this library! It's just what I need as I move my current project to Alpine 😀 

To make things even faster, I've added the ability to use APCu for caching the translations. This drastically improves performance and reduces memory usage with large translation files:

```
➜  motranslator git:(apcu-cache) ✗ php benchmark.php 
Execution took 17.254643917084 seconds
➜  motranslator git:(apcu-cache) ✗ php benchmark-apcu.php
Execution took 0.032136917114258 seconds
```

There is a slight performance hit when using in-memory cache, compared to the original code - around 0.0006s per request. I'm hoping that's acceptable:

```
➜  motranslator git:(master) ✗ php benchmark.php
Execution took 14.997493028641 seconds
```

I'm getting one PHPStan fail locally. That's not in code I touched, and actually looks like it's caused by a workaround to a previous false positive. I'll see if GH gets the same and if so fix it in a separate commit.