### PR TITLE
Implement PSR-6 Cache and Cache Factory support.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,8 @@
     "require-dev": {
         "phpunit/phpunit": "^7.4 || ^8 || ^9",
         "phpmyadmin/coding-standard": "^3.0.0",
-        "phpstan/phpstan": "^1.4.6"
+        "phpstan/phpstan": "^1.4.6",
+        "psr/cache": "^1.0|^2.0|^3.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/Cache/Psr6Cache.php
+++ b/src/Cache/Psr6Cache.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Cache;
+
+use PhpMyAdmin\MoTranslator\MoParser;
+use Psr\Cache\CacheItemPoolInterface;
+
+use function array_combine;
+use function array_keys;
+use function array_map;
+use function is_string;
+use function md5;
+
+final class Psr6Cache implements CacheInterface
+{
+    public const LOADED_KEY = '__TRANSLATIONS_LOADED__';
+
+    /** @var CacheItemPoolInterface */
+    private $psr6Cache;
+
+    /** @var MoParser */
+    private $parser;
+
+    /** @var string */
+    private $locale;
+
+    /** @var string */
+    private $domain;
+
+    /** @var int */
+    private $ttl;
+
+    /** @var bool */
+    private $reloadOnMiss;
+
+    /** @var string */
+    private $prefix;
+
+    /** @var string */
+    private $separator;
+
+    public function __construct(
+        CacheItemPoolInterface $psr6Cache,
+        MoParser $parser,
+        string $locale,
+        string $domain,
+        int $ttl = 0,
+        bool $reloadOnMiss = true,
+        string $prefix = 'mo_',
+        string $separator = '.'
+    ) {
+        $this->psr6Cache = $psr6Cache;
+        $this->parser = $parser;
+        $this->locale = $locale;
+        $this->domain = $domain;
+        $this->ttl = $ttl;
+        $this->reloadOnMiss = $reloadOnMiss;
+        $this->prefix = $prefix;
+        $this->separator = $separator;
+
+        $this->ensureTranslationsLoaded();
+    }
+
+    public function get(string $msgid): string
+    {
+        $cacheItem = $this->psr6Cache->getItem($this->getKey($msgid));
+        $cacheItemValue = $cacheItem->isHit() ? $cacheItem->get() : null;
+        if (is_string($cacheItemValue)) {
+            return $cacheItemValue;
+        }
+
+        if (! $this->reloadOnMiss) {
+            return $msgid;
+        }
+
+        $cacheItem->set($msgid);
+        if ($this->ttl > 0) {
+            $cacheItem->expiresAfter($this->ttl);
+        }
+
+        $this->psr6Cache->save($cacheItem);
+
+        // reload .mo file, in case entry has been evicted
+        $this->parser->parseIntoCache($this);
+
+        $cacheItem = $this->psr6Cache->getItem($this->getKey($msgid));
+        $cacheItemValue = $cacheItem->isHit() ? $cacheItem->get() : null;
+
+        return is_string($cacheItemValue)
+            ? $cacheItemValue
+            : $msgid;
+    }
+
+    public function set(string $msgid, string $msgstr): void
+    {
+        $cacheItem = $this->psr6Cache->getItem($this->getKey($msgid));
+        $cacheItem->set($msgstr);
+        if ($this->ttl > 0) {
+            $cacheItem->expiresAfter($this->ttl);
+        }
+
+        $this->psr6Cache->save($cacheItem);
+    }
+
+    public function has(string $msgid): bool
+    {
+        return $this->psr6Cache->hasItem($this->getKey($msgid));
+    }
+
+    public function setAll(array $translations): void
+    {
+        $keys = array_map(function (string $msgid): string {
+            return $this->getKey($msgid);
+        }, array_keys($translations));
+        $translations = array_combine($keys, $translations);
+
+        foreach ($this->psr6Cache->getItems($keys) as $cacheItem) {
+            $cacheItem->set($translations[$cacheItem->getKey()]);
+            if ($this->ttl > 0) {
+                $cacheItem->expiresAfter($this->ttl);
+            }
+
+            $this->psr6Cache->saveDeferred($cacheItem);
+        }
+
+        $this->psr6Cache->commit();
+    }
+
+    private function getKey(string $msgid): string
+    {
+        // Hash the message ID to avoid using restricted characters in various cache adapters.
+        return $this->prefix . $this->locale . $this->separator . $this->domain . $this->separator . md5($msgid);
+    }
+
+    private function ensureTranslationsLoaded(): void
+    {
+        // Try to prevent cache slam if multiple processes are trying to load translations. There is still a race
+        // between the exists check and creating the entry, but at least it's small
+        $cacheItem = $this->psr6Cache->getItem($this->getKey(self::LOADED_KEY));
+        if ($cacheItem->isHit()) {
+            return;
+        }
+
+        $this->parser->parseIntoCache($this);
+
+        $cacheItem->set(1);
+        if ($this->ttl > 0) {
+            $cacheItem->expiresAfter($this->ttl);
+        }
+
+        $this->psr6Cache->save($cacheItem);
+    }
+}

--- a/src/Cache/Psr6CacheFactory.php
+++ b/src/Cache/Psr6CacheFactory.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Cache;
+
+use PhpMyAdmin\MoTranslator\MoParser;
+use Psr\Cache\CacheItemPoolInterface;
+
+final class Psr6CacheFactory implements CacheFactoryInterface
+{
+    /** @var CacheItemPoolInterface */
+    private $psr6Cache;
+
+    /** @var int */
+    private $ttl;
+
+    /** @var bool */
+    private $reloadOnMiss;
+
+    /** @var string */
+    private $prefix;
+
+    /** @var string */
+    private $separator;
+
+    public function __construct(
+        CacheItemPoolInterface $psr6Cache,
+        int $ttl = 0,
+        bool $reloadOnMiss = true,
+        string $prefix = 'mo_',
+        string $separator = '.'
+    ) {
+        $this->psr6Cache = $psr6Cache;
+        $this->ttl = $ttl;
+        $this->reloadOnMiss = $reloadOnMiss;
+        $this->prefix = $prefix;
+        $this->separator = $separator;
+    }
+
+    public function getInstance(MoParser $parser, string $locale, string $domain): CacheInterface
+    {
+        return new Psr6Cache(
+            $this->psr6Cache,
+            $parser,
+            $locale,
+            $domain,
+            $this->ttl,
+            $this->reloadOnMiss,
+            $this->prefix,
+            $this->separator
+        );
+    }
+}

--- a/tests/Cache/Psr6CacheFactoryTest.php
+++ b/tests/Cache/Psr6CacheFactoryTest.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Tests\Cache;
+
+use PhpMyAdmin\MoTranslator\Cache\Psr6Cache;
+use PhpMyAdmin\MoTranslator\Cache\Psr6CacheFactory;
+use PhpMyAdmin\MoTranslator\MoParser;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+use function md5;
+use function sleep;
+
+/**
+ * @covers \PhpMyAdmin\MoTranslator\Cache\Psr6CacheFactory
+ */
+class Psr6CacheFactoryTest extends TestCase
+{
+    /** @var CacheItemPoolInterface */
+    protected $psr6Cache;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->psr6Cache = new ArrayAdapter();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->psr6Cache->clear();
+    }
+
+    public function testGetInstanceReturnsPsr6Cache(): void
+    {
+        $factory = new Psr6CacheFactory($this->psr6Cache);
+        $instance = $factory->getInstance(new MoParser(null), 'foo', 'bar');
+        $this->assertInstanceOf(Psr6Cache::class, $instance);
+    }
+
+    public function testConstructorSetsTtl(): void
+    {
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+        $ttl = 1;
+
+        $factory = new Psr6CacheFactory($this->psr6Cache, $ttl);
+
+        $parser = new MoParser(__DIR__ . '/../data/little.mo');
+        $factory->getInstance($parser, $locale, $domain);
+
+        sleep($ttl * 2);
+
+        $cacheItem = $this->psr6Cache->getItem('mo_' . $locale . '.' . $domain . '.' . md5($msgid));
+        $this->assertFalse($cacheItem->isHit());
+    }
+
+    public function testConstructorSetsReloadOnMiss(): void
+    {
+        $expected = 'Column';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+
+        $factory = new Psr6CacheFactory($this->psr6Cache, 0, false);
+        $parser = new MoParser(__DIR__ . '/../data/little.mo');
+
+        $instance = $factory->getInstance($parser, $locale, $domain);
+
+        $this->psr6Cache->deleteItem('mo_' . $locale . '.' . $domain . '.' . md5($msgid));
+
+        $actual = $instance->get($msgid);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testConstructorSetsPrefix(): void
+    {
+        $expected = 'Pole';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+        $prefix = 'baz_';
+
+        $factory = new Psr6CacheFactory($this->psr6Cache, 0, true, $prefix);
+        $parser = new MoParser(__DIR__ . '/../data/little.mo');
+
+        $factory->getInstance($parser, $locale, $domain);
+
+        $actual = $this->psr6Cache->getItem($prefix . $locale . '.' . $domain . '.' . md5($msgid))->get();
+        $this->assertSame($expected, $actual);
+    }
+}

--- a/tests/Cache/Psr6CacheTest.php
+++ b/tests/Cache/Psr6CacheTest.php
@@ -1,0 +1,287 @@
+<?php
+
+declare(strict_types=1);
+
+namespace PhpMyAdmin\MoTranslator\Tests\Cache;
+
+use PhpMyAdmin\MoTranslator\Cache\Psr6Cache;
+use PhpMyAdmin\MoTranslator\MoParser;
+use PHPUnit\Framework\TestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+use function chr;
+use function explode;
+use function implode;
+use function md5;
+use function sleep;
+
+/**
+ * @covers \PhpMyAdmin\MoTranslator\Cache\Psr6Cache
+ */
+class Psr6CacheTest extends TestCase
+{
+    /** @var CacheItemPoolInterface */
+    protected $psr6Cache;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->psr6Cache = new ArrayAdapter();
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        $this->psr6Cache->clear();
+    }
+
+    public function testConstructorLoadsCache(): void
+    {
+        $expected = 'Pole';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+
+        new Psr6Cache($this->psr6Cache, new MoParser(__DIR__ . '/../data/little.mo'), $locale, $domain);
+
+        $actual = $this->psr6Cache->getItem('mo_' . $locale . '.' . $domain . '.' . md5($msgid))->get();
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testConstructorSetsTtl(): void
+    {
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+        $ttl = 1;
+
+        new Psr6Cache($this->psr6Cache, new MoParser(__DIR__ . '/../data/little.mo'), $locale, $domain, $ttl);
+
+        sleep($ttl * 2);
+
+        $cacheItem = $this->psr6Cache->getItem('mo_' . $locale . '.' . $domain . '.' . md5($msgid));
+        $this->assertFalse($cacheItem->isHit());
+
+        $cacheItem = $this->psr6Cache->getItem('mo_' . $locale . '.' . $domain . '.' . md5(Psr6Cache::LOADED_KEY));
+        $this->assertFalse($cacheItem->isHit());
+    }
+
+    public function testConstructorSetsReloadOnMiss(): void
+    {
+        $expected = 'Column';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+        $prefix = 'baz_';
+
+        $cache = new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(__DIR__ . '/../data/little.mo'),
+            $locale,
+            $domain,
+            0,
+            false,
+            $prefix
+        );
+
+        $this->psr6Cache->deleteItem($prefix . $locale . '.' . $domain . '.' . md5($msgid));
+
+        $actual = $cache->get($msgid);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testConstructorSetsPrefix(): void
+    {
+        $expected = 'Pole';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+        $prefix = 'baz_';
+
+        new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(__DIR__ . '/../data/little.mo'),
+            $locale,
+            $domain,
+            0,
+            true,
+            $prefix
+        );
+
+        $actual = $this->psr6Cache->getItem($prefix . $locale . '.' . $domain . '.' . md5($msgid))->get();
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testEnsureTranslationsLoadedSetsLoadedKey(): void
+    {
+        $expected = 1;
+        $locale = 'foo';
+        $domain = 'bar';
+
+        new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(__DIR__ . '/../data/little.mo'),
+            $locale,
+            $domain
+        );
+
+        $actual = $this->psr6Cache->getItem('mo_' . $locale . '.' . $domain . '.' . md5(Psr6Cache::LOADED_KEY))->get();
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testGetReturnsMsgstr(): void
+    {
+        $expected = 'Pole';
+        $msgid = 'Column';
+
+        $cache = new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(__DIR__ . '/../data/little.mo'),
+            'foo',
+            'bar'
+        );
+
+        $actual = $cache->get($msgid);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testGetReturnsMsgidForCacheMiss(): void
+    {
+        $expected = 'Column';
+
+        $cache = new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(null),
+            'foo',
+            'bar'
+        );
+
+        $actual = $cache->get($expected);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testStoresMsgidOnCacheMiss(): void
+    {
+        $expected = 'Column';
+        $locale = 'foo';
+        $domain = 'bar';
+
+        $cache = new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(null),
+            $locale,
+            $domain
+        );
+        $cache->get($expected);
+
+        $actual = $this->psr6Cache->getItem('mo_' . $locale . '.' . $domain . '.' . md5($expected))->get();
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testGetReloadsOnCacheMiss(): void
+    {
+        $expected = 'Pole';
+        $locale = 'foo';
+        $domain = 'bar';
+        $msgid = 'Column';
+
+        $cache = new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(__DIR__ . '/../data/little.mo'),
+            $locale,
+            $domain
+        );
+
+        $this->psr6Cache->deleteItem('mo_' . $locale . '.' . $domain . '.' . md5(Psr6Cache::LOADED_KEY));
+
+        $actual = $cache->get($msgid);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testSetSetsMsgstr(): void
+    {
+        $expected = 'Pole';
+        $msgid = 'Column';
+
+        $cache = new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(null),
+            'foo',
+            'bar'
+        );
+        $cache->set($msgid, $expected);
+
+        $actual = $cache->get($msgid);
+        $this->assertSame($expected, $actual);
+    }
+
+    public function testHasReturnsFalse(): void
+    {
+        $cache = new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(null),
+            'foo',
+            'bar'
+        );
+
+        $actual = $cache->has('Column');
+        $this->assertFalse($actual);
+    }
+
+    public function testHasReturnsTrue(): void
+    {
+        $cache = new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(__DIR__ . '/../data/little.mo'),
+            'foo',
+            'bar'
+        );
+
+        $actual = $cache->has('Column');
+        $this->assertTrue($actual);
+    }
+
+    public function testSetAllSetsTranslations(): void
+    {
+        $translations = [
+            'foo' => 'bar',
+            'and' => 'another',
+        ];
+
+        $cache = new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(null),
+            'foo',
+            'bar'
+        );
+        $cache->setAll($translations);
+
+        foreach ($translations as $msgid => $expected) {
+            $actual = $cache->get($msgid);
+            $this->assertEquals($expected, $actual);
+        }
+    }
+
+    public function testCacheStoresPluralForms(): void
+    {
+        $expected = ['first', 'second'];
+
+        $plural = ["%d pig went to the market\n", "%d pigs went to the market\n"];
+        $msgid = implode(chr(0), $plural);
+
+        $cache = new Psr6Cache(
+            $this->psr6Cache,
+            new MoParser(null),
+            'foo',
+            'bar'
+        );
+        $cache->set($msgid, implode(chr(0), $expected));
+
+        $msgstr = $cache->get($msgid);
+        $actual = explode(chr(0), $msgstr);
+        $this->assertSame($expected, $actual);
+    }
+}


### PR DESCRIPTION
Hello!

Across all of my applications, I make use of the PSR standards whenever possible for ease of interoperability. I noticed that this library supports caching adapters, but didn't yet support the popular PSR-6 standard.

This PR adds full implementations and test coverage for PSR-6 cache adapter support.

In this library's case, since it already includes `symfony/cache` by virtue of its other library dependencies, and since Symfony Cache's adapters are themselves PSR-6 compatible, it's possible that in the long run, this could be the _only_ adapter you need to ship with this library, since both in-memory and APCu are offered by Symfony Cache. In fact, the test coverage takes advantage of this fact by using Symfony's `ArrayAdapter` as a sample PSR-6 implementation.

Let me know if you have any questions!