### PR TITLE
Fix misspelling of APCu

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ If you are using `Loader`, pass it an `ApcuCacheFactory` _before_ getting the tr
 
 ```php
 PhpMyAdmin\MoTranslator\Loader::setCacheFactory(
-    new PhpMyAdmin\MoTranslator\Cache\AcpuCacheFactory()
+    new PhpMyAdmin\MoTranslator\Cache\ApcuCacheFactory()
 );
 $loader = new PhpMyAdmin\MoTranslator\Loader();
 
@@ -160,7 +160,7 @@ to the `ApcuCacheFactory` or when instantiating `ApcuCache`:
 
 ```php
 PhpMyAdmin\MoTranslator\Loader::setCacheFactory(
-    new PhpMyAdmin\MoTranslator\Cache\AcpuCacheFactory(
+    new PhpMyAdmin\MoTranslator\Cache\ApcuCacheFactory(
         3600,     // cache for 1 hour
         true,     // reload on cache miss
         'custom_' // custom prefix for cache entries

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
         "vimeo/psalm": "^6.8"
     },
     "suggest": {
-        "ext-apcu": "Needed for ACPu-backed translation cache"
+        "ext-apcu": "Needed for APCu-backed translation cache"
     },
     "autoload": {
         "psr-4": {

--- a/src/Cache/ApcuCache.php
+++ b/src/Cache/ApcuCache.php
@@ -33,7 +33,7 @@ final class ApcuCache implements CacheInterface
         private string $prefix = 'mo_',
     ) {
         if (! (function_exists('apcu_enabled') && apcu_enabled())) {
-            throw new CacheException('ACPu extension must be installed and enabled');
+            throw new CacheException('APCu extension must be installed and enabled');
         }
 
         $this->ensureTranslationsLoaded();

--- a/tests/Cache/ApcuCacheFactoryTest.php
+++ b/tests/Cache/ApcuCacheFactoryTest.php
@@ -28,7 +28,7 @@ class ApcuCacheFactoryTest extends TestCase
             return;
         }
 
-        $this->markTestSkipped('ACPu extension is not installed and enabled for CLI');
+        $this->markTestSkipped('APCu extension is not installed and enabled for CLI');
     }
 
     protected function tearDown(): void

--- a/tests/Cache/ApcuCacheTest.php
+++ b/tests/Cache/ApcuCacheTest.php
@@ -32,7 +32,7 @@ class ApcuCacheTest extends TestCase
             return;
         }
 
-        $this->markTestSkipped('ACPu extension is not installed and enabled for CLI');
+        $this->markTestSkipped('APCu extension is not installed and enabled for CLI');
     }
 
     protected function tearDown(): void

--- a/tests/Cache/ApcuDisabledTest.php
+++ b/tests/Cache/ApcuDisabledTest.php
@@ -21,7 +21,7 @@ final class ApcuDisabledTest extends TestCase
         }
 
         $this->expectException(CacheException::class);
-        $this->expectExceptionMessage('ACPu extension must be installed and enabled');
+        $this->expectExceptionMessage('APCu extension must be installed and enabled');
         new ApcuCache(new MoParser(null), 'foo', 'bar');
     }
 }


### PR DESCRIPTION
"APCu" was misspelled in several places as "ACPu". Just docs and error strings, so nothing that would actually break the library.

This PR fixes the typos.